### PR TITLE
Fix HTTPS tunneling

### DIFF
--- a/src/proxyclient.h
+++ b/src/proxyclient.h
@@ -56,6 +56,7 @@ signals:
 
 private slots:
     void handleSslSocketConnected();
+    void handleSslSocketEncrypted();
     void handleSslSocketDisconnected();
     void handleSslSocketError(QAbstractSocket::SocketError error);
     void handleSslErrors(const QList<QSslError> &errors);


### PR DESCRIPTION
## Summary
- establish TCP connection to proxy first
- start TLS after CONNECT response
- send HTTP request once TLS handshake finishes

## Testing
- `qmake EasyProxyClient.pro` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861548dbb8c83319847fe26bbb54862