### PR TITLE
Update release workflow to upload exe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,10 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: EasyProxyClient
-        path: release.zip
-        retention-days: 30 
+        path: |
+          release.zip
+          bin/release/EasyProxyClient.exe
+        retention-days: 30
 
     - name: Get existing Release upload URL
       id: get_release
@@ -98,5 +100,6 @@ jobs:
       with:
         files: |
           release.zip
+          bin/release/EasyProxyClient.exe
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- upload built exe as a separate artifact
- attach the exe to GitHub releases along with the zipped release

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68621c19ce848331b52bf65d41b15dd5