### PR TITLE
Implement tunnel socket after CONNECT

### DIFF
--- a/src/proxyclient.h
+++ b/src/proxyclient.h
@@ -71,7 +71,12 @@ private:
     void parseHttpResponse();
     void showError(const QString &message);
 
-    QSslSocket *sslSocket;
+    // 与代理通信的socket
+    QSslSocket *proxySocket;
+    // 与目标服务器通信的socket，建立在代理隧道之上
+    QSslSocket *tunnelSocket;
+    // 当前活动的socket，用于读写数据
+    QSslSocket *currentSocket;
     QTimer *connectionTimer;
     
     // 代理设置


### PR DESCRIPTION
## Summary
- refactor `ProxyClient` to use a dedicated socket for the proxy and create a new socket for the target server after receiving `200 Connection Established`
- keep a `currentSocket` pointer for unified read/write operations

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68622ceda3c883319f94d80c1a16221a