### PR TITLE
Use libcurl for proxy TLS flow

### DIFF
--- a/EasyProxyClient.pro
+++ b/EasyProxyClient.pro
@@ -1,4 +1,4 @@
-QT += core widgets network
+QT += core widgets network concurrent
 
 CONFIG += c++11
 
@@ -40,4 +40,7 @@ UI_DIR = build/ui
 OBJECTS_DIR = build/obj
 
 # 清理构建目录
-QMAKE_CLEAN += -r build/ 
+QMAKE_CLEAN += -r build/
+
+# libcurl
+LIBS += -lcurl

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ EasyProxyClient 是面向 [EasyProxy](https://github.com/SwartzMss/EasyProxy) �
 - 下载 Visual Studio Community：https://visualstudio.microsoft.com/
 - 安装时选择"C++桌面开发"工作负载
 
+#### 安装 libcurl
+- 安装 libcurl 库（需要包含开发头文件）
+- Windows 用户可从 <https://curl.se/windows/> 下载预编译包
+
 ### 2. 构建项目
 
 #### 方法一：使用 Qt Creator（推荐）

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -151,7 +151,6 @@ void MainWindow::setupConnections()
     // 连接代理客户端信号
     connect(proxyClient, &ProxyClient::connectionStarted, this, &MainWindow::onConnectionStarted);
     connect(proxyClient, &ProxyClient::connectionFinished, this, &MainWindow::onConnectionFinished);
-    connect(proxyClient, &ProxyClient::sslErrors, this, &MainWindow::onSslErrors);
     connect(proxyClient, &ProxyClient::networkError, this, &MainWindow::onNetworkError);
     connect(proxyClient, &ProxyClient::debugMessage, this, &MainWindow::onDebugMessage);
 }
@@ -261,10 +260,6 @@ void MainWindow::onConnectionFinished(bool success, const QString &result)
     }
 }
 
-void MainWindow::onSslErrors(const QString &errorMessage)
-{
-    QMessageBox::warning(this, "SSL错误", errorMessage);
-}
 
 void MainWindow::onNetworkError(const QString &errorMessage)
 {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -35,7 +35,6 @@ private slots:
     void connectToProxy();
     void onConnectionStarted();
     void onConnectionFinished(bool success, const QString &result);
-    void onSslErrors(const QString &errorMessage);
     void onNetworkError(const QString &errorMessage);
     void onDebugMessage(const QString &message);
     

--- a/src/proxyclient.cpp
+++ b/src/proxyclient.cpp
@@ -1,37 +1,29 @@
 #include "proxyclient.h"
 #include <QDateTime>
-#include <QFile>
 #include <QUrl>
 #include <QDebug>
+#include <QMetaObject>
 
-// ───────────────────────────────────────────────────────────────────────────────
 ProxyClient::ProxyClient(QObject *parent)
     : QObject(parent),
-      socket_(new QSslSocket(this)),
       timer_(new QTimer(this))
 {
-    // socket signals
-    connect(socket_, &QSslSocket::connected,       this, &ProxyClient::onSocketConnected);
-    connect(socket_, &QSslSocket::encrypted,       this, &ProxyClient::onSocketEncrypted);
-    connect(socket_, &QSslSocket::readyRead,       this, &ProxyClient::onSocketReadyRead);
-    connect(socket_, &QSslSocket::disconnected,    this, &ProxyClient::onSocketDisconnected);
-    connect(socket_, &QSslSocket::errorOccurred,   this, &ProxyClient::onSocketError);
-    connect(socket_, &QSslSocket::sslErrors,       this, &ProxyClient::onSslErrors);
-
-    // timeout
     timer_->setSingleShot(true);
-    connect(timer_, &QTimer::timeout, this, &ProxyClient::onConnectionTimeout);
+    connect(timer_, &QTimer::timeout, this, [this]() {
+        if (connecting_) {
+            finishWithError(tr("连接超时"));
+        }
+    });
 }
 
 ProxyClient::~ProxyClient()
 {
-    if (socket_)
-        socket_->disconnectFromHost();
+    cancelRequest();
 }
 
-// ───────────────────────────────────────────────────────────────────────────────
 void ProxyClient::setProxySettings(const QString &host, int port,
-                                   const QString &username, const QString &password)
+                                   const QString &username,
+                                   const QString &password)
 {
     proxyHost_ = host;
     proxyPort_ = port;
@@ -44,7 +36,6 @@ void ProxyClient::setSslCertificate(const QString &certificatePath)
     caPath_ = certificatePath;
 }
 
-// ───────────────────────────────────────────────────────────────────────────────
 void ProxyClient::appendDebug(const QString &msg)
 {
     const QString stamped = QString("[%1] %2")
@@ -59,11 +50,9 @@ void ProxyClient::finishWithError(const QString &msg)
     appendDebug("ERROR: " + msg);
     connecting_ = false;
     timer_->stop();
-    socket_->disconnectFromHost();
     emit connectionFinished(false, msg);
 }
 
-// ───────────────────────────────────────────────────────────────────────────────
 void ProxyClient::connectToUrl(const QString &url)
 {
     if (connecting_) {
@@ -82,213 +71,110 @@ void ProxyClient::connectToUrl(const QString &url)
         return;
     }
 
-    // set target
-    targetUrl_  = url;
-    targetHost_ = u.host();
-    targetPort_ = u.port(443);
+    targetUrl_ = url;
 
-    // reset state
-    buffer_.clear();
-    stage_      = Stage::ProxyTlsHandshake;
     connecting_ = true;
+    headerBuffer_.clear();
+    bodyBuffer_.clear();
     debugLines_.clear();
 
     emit connectionStarted();
     appendDebug(tr("开始连接流程 -> %1 via %2:%3").arg(targetUrl_).arg(proxyHost_).arg(proxyPort_));
 
-    // timeout 30s
-    timer_->start(30'000);
+    timer_->start(30'000); // 30s timeout
 
-    // SSL config & connect
-    socket_->setSslConfiguration(buildSslConfiguration());
-    appendDebug(tr("正在 TLS 连接代理服务器 %1:%2 ...").arg(proxyHost_).arg(proxyPort_));
-    socket_->connectToHostEncrypted(proxyHost_, proxyPort_);
+    worker_ = QThread::create([this]() { performRequest(); });
+    connect(worker_, &QThread::finished, worker_, &QObject::deleteLater);
+    worker_->start();
 }
 
 void ProxyClient::cancelRequest()
 {
-    if (!connecting_)
-        return;
     connecting_ = false;
     timer_->stop();
-    socket_->disconnectFromHost();
-    emit networkError(tr("请求已取消"));
-}
-
-// ───────────────────────────────────────────────────────────────────────────────
-QSslConfiguration ProxyClient::buildSslConfiguration() const
-{
-    QSslConfiguration cfg = QSslConfiguration::defaultConfiguration();
-    if (!caPath_.isEmpty()) {
-        QFile f(caPath_);
-        if (f.open(QIODevice::ReadOnly)) {
-            const QSslCertificate cert(&f);
-            if (!cert.isNull()) {
-                auto list = cfg.caCertificates();
-                list.append(cert);
-                cfg.setCaCertificates(list);
-            }
-        }
+    if (worker_) {
+        worker_->quit();
+        worker_->wait();
+        worker_ = nullptr;
     }
-    cfg.setPeerVerifyMode(QSslSocket::VerifyNone);   // accept any proxy cert
-    return cfg;
 }
 
-// ───────────────────────────────────────────────────────────────────────────────
-void ProxyClient::onSocketConnected()
+size_t ProxyClient::headerCallback(char *buffer, size_t size, size_t nitems, void *userdata)
 {
-    appendDebug("TCP 链接已建立 (待 TLS 握手)");
+    ProxyClient *self = static_cast<ProxyClient *>(userdata);
+    QByteArray data(buffer, size * nitems);
+    self->headerBuffer_.append(data);
+    QMetaObject::invokeMethod(self, [self, data]() { self->appendDebug(QString::fromUtf8(data).trimmed()); }, Qt::QueuedConnection);
+    return size * nitems;
 }
 
-void ProxyClient::onSocketEncrypted()
+size_t ProxyClient::writeCallback(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
-    if (stage_ == Stage::ProxyTlsHandshake) {
-        appendDebug("与代理 TLS 握手完成，发送 CONNECT 请求 ...");
-        sendConnectRequest();
-        stage_ = Stage::WaitProxyResponse;
+    ProxyClient *self = static_cast<ProxyClient *>(userdata);
+    self->bodyBuffer_.append(ptr, size * nmemb);
+    return size * nmemb;
+}
+
+void ProxyClient::performRequest()
+{
+    CURL *curl = curl_easy_init();
+    if (!curl) {
+        QMetaObject::invokeMethod(this, [this]() { finishWithError(tr("初始化curl失败")); }, Qt::QueuedConnection);
         return;
     }
 
-    if (stage_ == Stage::TargetTlsHandshake) {
-        appendDebug("与目标站点 TLS 握手完成，可发送 HTTP 请求 ...");
-        stage_ = Stage::Ready;
-        // now send the actual HTTP GET
-        socket_->setPeerVerifyName(targetHost_); // already set, but safe
-        socket_->flush();
-        // send request immediately
-        QString path = QUrl(targetUrl_).path();
-        if (path.isEmpty()) path = "/";
-        QString req = QString("GET %1 HTTP/1.1\r\nHost: %2\r\nUser-Agent: EasyProxyClient/2.0\r\nConnection: close\r\n\r\n")
-                           .arg(path, targetHost_);
-        appendDebug("发送 HTTP 请求:\n" + req);
-        socket_->write(req.toUtf8());
-        return;
-    }
-
-    // unexpected
-    appendDebug("onSocketEncrypted: unexpected stage");
-}
-
-void ProxyClient::onSocketReadyRead()
-{
-    buffer_.append(socket_->readAll());
-
-    if (stage_ == Stage::WaitProxyResponse) {
-        if (tryParseConnectResponse()) {
-            // CONNECT success, begin second TLS handshake
-            stage_ = Stage::TargetTlsHandshake;
-            socket_->setPeerVerifyName(targetHost_);
-            socket_->startClientEncryption();
-        }
-        return;
-    }
-
-    if (stage_ == Stage::Ready) {
-        if (tryParseHttpResponse()) {
-            connecting_ = false;
-            timer_->stop();
-            socket_->disconnectFromHost();
-        }
-    }
-}
-
-void ProxyClient::onSocketDisconnected()
-{
-    appendDebug("socket disconnected");
-    if (connecting_) {
-        finishWithError(tr("连接中途断开"));
-    }
-}
-
-void ProxyClient::onSocketError(QAbstractSocket::SocketError error)
-{
-    Q_UNUSED(error);
-    finishWithError(socket_->errorString());
-}
-
-void ProxyClient::onSslErrors(const QList<QSslError> &errors)
-{
-    QStringList lines;
-    for (const auto &e : errors) lines << e.errorString();
-    appendDebug("代理 TLS 证书错误 (忽略):\n" + lines.join("\n"));
-    socket_->ignoreSslErrors();
-}
-
-void ProxyClient::onConnectionTimeout()
-{
-    if (!connecting_) return;
-    finishWithError(tr("连接超时"));
-}
-
-// ───────────────────────────────────────────────────────────────────────────────
-void ProxyClient::sendConnectRequest()
-{
-    QString req = QString("CONNECT %1:%2 HTTP/1.1\r\nHost: %1:%2\r\n")
-                      .arg(targetHost_).arg(targetPort_);
+    curl_easy_setopt(curl, CURLOPT_URL, targetUrl_.toUtf8().constData());
+    curl_easy_setopt(curl, CURLOPT_PROXY, proxyHost_.toUtf8().constData());
+    curl_easy_setopt(curl, CURLOPT_PROXYPORT, proxyPort_);
+    curl_easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTPS);
+    curl_easy_setopt(curl, CURLOPT_HTTPPROXYTUNNEL, 1L);
 
     if (!proxyUser_.isEmpty()) {
-        const QByteArray token = QString("%1:%2").arg(proxyUser_, proxyPass_).toUtf8().toBase64();
-        req += QString("Proxy-Authorization: Basic %1\r\n").arg(QString::fromUtf8(token));
+        QByteArray auth = QString("%1:%2").arg(proxyUser_, proxyPass_).toUtf8();
+        curl_easy_setopt(curl, CURLOPT_PROXYUSERPWD, auth.constData());
     }
 
-    req += "User-Agent: EasyProxyClient/2.0\r\nConnection: keep-alive\r\n\r\n";
-    appendDebug("发送 CONNECT 请求:\n" + req);
-    socket_->write(req.toUtf8());
-}
-
-bool ProxyClient::tryParseConnectResponse()
-{
-    int headerEnd = buffer_.indexOf("\r\n\r\n");
-    if (headerEnd == -1) return false;  // not yet
-
-    const QByteArray header = buffer_.left(headerEnd + 4);
-    appendDebug("收到 CONNECT 响应:\n" + QString::fromUtf8(header));
-
-    if (!header.contains(" 200 ")) {
-        finishWithError(tr("CONNECT 失败"));
-        return false;
+    if (!caPath_.isEmpty()) {
+        curl_easy_setopt(curl, CURLOPT_CAINFO, caPath_.toUtf8().constData());
+        curl_easy_setopt(curl, CURLOPT_PROXY_CAINFO, caPath_.toUtf8().constData());
     }
 
-    buffer_.remove(0, headerEnd + 4);
-    return true;
-}
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
+    curl_easy_setopt(curl, CURLOPT_PROXY_SSL_VERIFYPEER, 1L);
+    curl_easy_setopt(curl, CURLOPT_PROXY_SSL_VERIFYHOST, 2L);
 
-bool ProxyClient::tryParseHttpResponse()
-{
-    int headerEnd = buffer_.indexOf("\r\n\r\n");
-    if (headerEnd == -1) return false;
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, &ProxyClient::headerCallback);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, this);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &ProxyClient::writeCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, this);
 
-    const QByteArray header = buffer_.left(headerEnd + 4);
-    if (!header.startsWith("HTTP/")) return false;
+    CURLcode res = curl_easy_perform(curl);
+    long response = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
+    curl_easy_cleanup(curl);
 
-    appendDebug("收到 HTTP 头:\n" + QString::fromUtf8(header));
-
-    // simple Content-Length check
-    int contentLength = -1;
-    const QByteArray key("Content-Length:");
-    int idx = header.indexOf(key);
-    if (idx != -1) {
-        int lineEnd = header.indexOf("\r\n", idx);
-        if (lineEnd != -1) {
-            contentLength = header.mid(idx + key.size(), lineEnd - idx - key.size()).trimmed().toInt();
+    QMetaObject::invokeMethod(this, [this, res, response]() {
+        timer_->stop();
+        connecting_ = false;
+        if (res != CURLE_OK) {
+            finishWithError(QString::fromUtf8(curl_easy_strerror(res)));
+            return;
         }
-    }
+        if (response < 200 || response >= 300) {
+            finishWithError(tr("HTTP 状态码 %1").arg(response));
+            return;
+        }
 
-    if (contentLength >= 0 && buffer_.size() - (headerEnd + 4) < contentLength)
-        return false; // body incomplete
-
-    QByteArray body = buffer_.mid(headerEnd + 4);
-
-    QString result;
-    result += "=== 连接成功 ===\n";
-    result += QString("HTTP 返回 %1 字节\n\n").arg(body.size());
-    if (body.startsWith("<!DOCTYPE") || body.startsWith("<html")) {
-        result += QString::fromUtf8(body);
-    } else {
-        result += QString("[二进制内容, 前 128 字节十六进制]\n%1")
-                          .arg(QString(body.left(128).toHex(' ')));
-    }
-
-    emit connectionFinished(true, result);
-    return true;
+        QString result;
+        result += "=== 连接成功 ===\n";
+        result += QString("HTTP 状态 %1\n\n").arg(response);
+        if (bodyBuffer_.startsWith("<!DOCTYPE") || bodyBuffer_.startsWith("<html")) {
+            result += QString::fromUtf8(bodyBuffer_);
+        } else {
+            result += QString("[二进制内容, 前 128 字节十六进制]\n%1")
+                          .arg(QString(bodyBuffer_.left(128).toHex(' ')));
+        }
+        emit connectionFinished(true, result);
+    }, Qt::QueuedConnection);
 }

--- a/src/proxyclient.h
+++ b/src/proxyclient.h
@@ -2,89 +2,54 @@
 #define PROXYCLIENT_H
 
 #include <QObject>
-#include <QSslSocket>
-#include <QSslConfiguration>
-#include <QSslCertificate>
-#include <QSslError>
-#include <QTimer>
 #include <QStringList>
+#include <QThread>
+#include <QTimer>
+#include <curl/curl.h>
 
 class ProxyClient : public QObject
 {
     Q_OBJECT
-
 public:
     explicit ProxyClient(QObject *parent = nullptr);
     ~ProxyClient() override;
 
-    // ---- Public API ---------------------------------------------------
     void setProxySettings(const QString &host, int port,
                           const QString &username = {},
                           const QString &password = {});
     void setSslCertificate(const QString &certificatePath);
-    void connectToUrl(const QString &url);          // begin full TLS→CONNECT→TLS flow
+    void connectToUrl(const QString &url);
     void cancelRequest();
     bool isConnecting() const { return connecting_; }
 
 signals:
     void connectionStarted();
     void connectionFinished(bool success, const QString &result);
-    void sslErrors(const QString &errorMessage);
     void networkError(const QString &errorMessage);
     void debugMessage(const QString &message);
 
-private slots:
-    // QSslSocket handlers
-    void onSocketConnected();
-    void onSocketEncrypted();
-    void onSocketReadyRead();
-    void onSocketDisconnected();
-    void onSocketError(QAbstractSocket::SocketError error);
-    void onSslErrors(const QList<QSslError> &errors);
-
-    // timeout guard
-    void onConnectionTimeout();
-
 private:
-    // ---- Internal helpers --------------------------------------------
-    enum class Stage {
-        ProxyTlsHandshake,
-        WaitProxyResponse,
-        TargetTlsHandshake,
-        Ready
-    };
-
-    QSslConfiguration buildSslConfiguration() const;
-    void sendConnectRequest();
-    bool tryParseConnectResponse();           // returns true when CONNECT finished
-    bool tryParseHttpResponse();              // returns true when HTTP finished
     void appendDebug(const QString &msg);
     void finishWithError(const QString &msg);
+    void performRequest();
+    static size_t headerCallback(char *buffer, size_t size, size_t nitems, void *userdata);
+    static size_t writeCallback(char *ptr, size_t size, size_t nmemb, void *userdata);
 
-    // ---- Data ---------------------------------------------------------
-    QSslSocket   *socket_         { nullptr };
-    QTimer       *timer_          { nullptr };
+    QThread *worker_ { nullptr };
+    QTimer  *timer_  { nullptr };
 
-    // proxy
     QString proxyHost_;
-    int     proxyPort_            { 8080 };
+    int     proxyPort_ { 8080 };
     QString proxyUser_;
     QString proxyPass_;
 
-    // certificate
     QString caPath_;
-
-    // target
     QString targetUrl_;
-    QString targetHost_;
-    int     targetPort_           { 443 };
 
-    // state
-    bool  connecting_             { false };
-    Stage stage_                  { Stage::ProxyTlsHandshake };
-    QByteArray buffer_;                               // unified receive buffer
-
-    // debug
+    QByteArray headerBuffer_;
+    QByteArray bodyBuffer_;
+    bool connecting_ { false };
     QStringList debugLines_;
 };
+
 #endif // PROXYCLIENT_H


### PR DESCRIPTION
## Summary
- replace QSslSocket-based proxy code with libcurl implementation
- clean up GUI hooks for removed sslErrors signal
- add libcurl to project file and README

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686246ad2b14833190aab08eecbf41f8