### PR TITLE
Fix missing libcurl.lib in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,16 @@ jobs:
     
     - name: Setup MSVC
       uses: ilammy/msvc-dev-cmd@v1
-    
+
+    - name: Generate libcurl import library
+      shell: cmd
+      run: |
+        cd depend\libcurl
+        if not exist lib mkdir lib
+        cd bin
+        dumpbin /exports libcurl.dll > ..\libcurl.def
+        lib /def:..\libcurl.def /machine:x64 /out:..\lib\libcurl.lib
+
     - name: Configure
       shell: cmd
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,16 @@ jobs:
     
     - name: Setup MSVC
       uses: ilammy/msvc-dev-cmd@v1
-    
+
+    - name: Generate libcurl import library
+      shell: cmd
+      run: |
+        cd depend\libcurl
+        if not exist lib mkdir lib
+        cd bin
+        dumpbin /exports libcurl.dll > ..\libcurl.def
+        lib /def:..\libcurl.def /machine:x64 /out:..\lib\libcurl.lib
+
     - name: Configure
       shell: cmd
       run: |


### PR DESCRIPTION
## Summary
- ensure that libcurl import library is generated on CI

## Testing
- `python -` attempt to import PyYAML (failed: ModuleNotFoundError)


------
https://chatgpt.com/codex/tasks/task_e_68627835b7548331b8c7c0e4df3e8891